### PR TITLE
Fix checking for an at-sign filename $paramValue.

### DIFF
--- a/src/OAuthSimple.php
+++ b/src/OAuthSimple.php
@@ -457,24 +457,25 @@ class OAuthSimple
                 continue;
             }
             // Read parameters from a file. Hope you're practicing safe PHP.
-            if (strpos($paramValue, '@') !== 0) {
-                
+            if (strpos($paramValue, '@') === 0) {
                 try {
                     $file_exists = file_exists(substr($paramValue, 1));
                 } catch (\ErrorException $e) {
                     $file_exists = false;
                 }
 
-                if(!$file_exists) {
-                    if (is_array($paramValue)) {
-                        $normalized_keys[self::oauthEscape($paramName)] = array();
-                        foreach ($paramValue as $item) {
-                            array_push($normalized_keys[self::oauthEscape($paramName)], self::oauthEscape($item));
-                        }
-                    } else {
-                        $normalized_keys[self::oauthEscape($paramName)] = self::oauthEscape($paramValue);
-                    }
+                if ($file_exists) {
+                    continue;
                 }
+            }
+
+            if (is_array($paramValue)) {
+                $normalized_keys[self::oauthEscape($paramName)] = array();
+                foreach ($paramValue as $item) {
+                    array_push($normalized_keys[self::oauthEscape($paramName)], self::oauthEscape($item));
+                }
+            } else {
+                $normalized_keys[self::oauthEscape($paramName)] = self::oauthEscape($paramValue);
             }
         }
 


### PR DESCRIPTION
I've discovered a bug from the original OAuthSimple project which was carried over to this project. I go intro more detail in the pull request from that project: https://github.com/jrconlin/oauthsimple/pull/33

This pull request makes a similar change, but altered due to differences with this project.
